### PR TITLE
Change point.h to C99 inline semantics to support GCC Version 5+

### DIFF
--- a/lab3/starter/mqueue/point.h
+++ b/lab3/starter/mqueue/point.h
@@ -12,8 +12,8 @@ struct point {
 	int y;	/* y coordinate */
 };
 
-inline void set_position(int x, int y, struct point *buf);
-inline int get_x_coord (struct point p);
-inline int get_y_coord (struct point p);
+extern void set_position(int x, int y, struct point *buf);
+extern int get_x_coord (struct point p);
+extern int get_y_coord (struct point p);
 
 #endif /* POINT_H_ */


### PR DESCRIPTION
According to https://www.greenend.org.uk/rjk/tech/inline.html. We should change `inline `to `extern` in **point.h** header file so the code is compatible with both C89 and C99 standard.